### PR TITLE
SGE status fallback

### DIFF
--- a/src/scripts/sge_status.sh
+++ b/src/scripts/sge_status.sh
@@ -23,6 +23,8 @@
 #[ -f ${GLITE_LOCATION:-/opt/glite}/etc/blah.config ] && . ${GLITE_LOCATION:-/opt/glite}/etc/blah.config
 . `dirname $0`/blah_load_config.sh
 
+sge_helper_path=${GLITE_LOCATION:-/opt/glite}/bin
+
 usage_string="Usage: $0 [-w] [-n]"
 
 #get worker node info
@@ -63,7 +65,7 @@ fi
 tmpid=`echo "$@"|sed 's/.*\/.*\///g'`
 
 # ASG Keith way
-jobid=${tmpid}.default
+jobid=${tmpid}.${sge_cellname:-default}
 
 
 blahp_status=`exec ${sge_helper_path:-/opt/glite/bin}/sge_helper --status $getwn $jobid`


### PR DESCRIPTION
sge_helper is a perl script that includes a non-standard perl library, XML::Simple.  Also, perl will not be installed by default on rhel 7 (based on fedora 18).  Therefore, this pull request adds a fallback method of finding the status of a job if, and only if, the sge_helper exits with a non-zero exit code.

Additionally it provides a method for configuring the sge cell name, and provides a sane path for sge_helper.
