### PR TITLE
SGE status fallback

### DIFF
--- a/src/scripts/sge_status.sh
+++ b/src/scripts/sge_status.sh
@@ -23,6 +23,8 @@
 #[ -f ${GLITE_LOCATION:-/opt/glite}/etc/blah.config ] && . ${GLITE_LOCATION:-/opt/glite}/etc/blah.config
 . `dirname $0`/blah_load_config.sh
 
+sge_helper_path=${GLITE_LOCATION:-/opt/glite}/bin
+
 usage_string="Usage: $0 [-w] [-n]"
 
 #get worker node info
@@ -63,7 +65,7 @@ fi
 tmpid=`echo "$@"|sed 's/.*\/.*\///g'`
 
 # ASG Keith way
-jobid=${tmpid}.default
+jobid=${tmpid}.${sge_cellname:-default}
 
 
 blahp_status=`exec ${sge_helper_path:-/opt/glite/bin}/sge_helper --status $getwn $jobid`

--- a/src/scripts/sge_status.sh
+++ b/src/scripts/sge_status.sh
@@ -69,5 +69,42 @@ jobid=${tmpid}.default
 blahp_status=`exec ${sge_helper_path:-/opt/glite/bin}/sge_helper --status $getwn $jobid`
 retcode=$?
 
+# Now see if we need to run qstat 'manually'
+if [ $retcode -ne 0 ]; then
+
+   qstat_out=`qstat`
+
+   # First, find the column with the State information:
+   state_col=`echo "$qstat_out" | head -n 1 | awk '{ for (i = 1; i<=NF; i++) if ($i == "state") print i;}'`
+
+   # Now look up the status of the job
+   job_state=`echo "$qstat_out" | awk -v "STATE_COL=$state_col" -v "JOBID=$tmpid" '{ if ($1 == JOBID) print $STATE_COL; }'`
+ 
+   # Parse out the state of the job (blatantly stolen from sge_helper)
+   if [[ "$job_state" =~  q ]]; then
+      jobstatus=1
+   elif [[ "$job_state" =~ [rt] ]]; then
+      jobstatus=2
+   elif [[ "$job_state" =~ h ]]; then
+      jobstatus=5
+   elif [[ "$job_state" =~ E ]]; then
+      jobstatus=4
+   elif [[ "$job_state" =~ d ]]; then
+      jobstatus=3
+   elif [ "x$job_state" == "x" ]; then
+      jobstatus=4
+   fi
+
+   # If the job is done (either done state, or disappeared from qstat)
+   # fake an exit code.
+   if [ $jobstatus -eq 4 ]; then
+      blahp_status="[BatchJobId=\"$tmpid\";JobStatus=$jobstatus;ExitCode=0]"
+   else
+      blahp_status="[BatchJobId=\"$tmpid\";JobStatus=$jobstatus]"
+   fi
+   retcode=0
+
+fi
+
 echo ${retcode}${blahp_status}
 #exit $retcode


### PR DESCRIPTION
sge_helper is a perl script that includes a non-standard perl library, XML::Simple. Also, perl will not be installed by default on rhel 7 (based on fedora 18). Therefore, this pull request adds a fallback method of finding the status of a job if, and only if, the sge_helper exits with a non-zero exit code.

Additionally it provides a method for configuring the sge cell name, and provides a sane path for sge_helper.