### PR TITLE
Add job completion detection when PBS does not put jobs into C state

### DIFF
--- a/src/scripts/pbs_status.sh
+++ b/src/scripts/pbs_status.sh
@@ -169,7 +169,9 @@ for  reqfull in $pars ; do
 
         staterr=/tmp/${reqjob}_staterr
 	
-result=`${pbs_binpath}/qstat -f $reqjob 2>$staterr | awk -v jobId=$reqjob '
+result=`${pbs_binpath}/qstat -f $reqjob 2>$staterr`
+qstat_exit_code=$?
+result=`echo "$result" | awk -v jobId=$reqjob '
 BEGIN {
     current_job = ""
     current_wn = ""
@@ -222,6 +224,11 @@ END {
 	
         if [ -z "$errout" ] ; then
                 echo "0"$result
+                retcode=0
+        elif [ "$qstat_exit_code" -eq "153" ] ; then
+                # If the job has disappeared, assume it's completed 
+                # (same as globus)
+                echo "0[BatchJobId=\"$reqjob\";JobStatus=4;ExitCode=0]"
                 retcode=0
         else
                 echo "1ERROR: Job not found"


### PR DESCRIPTION
Default builds and configurations of PBS do not put jobs into C state.  This commit adds detection for this, and adds logic in order to count  the job as completed if it has disappeared from the qstat list (using logic borrowed from globus)
